### PR TITLE
Improve bundle size

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function parse(selector) {
     children: []
   };
 
-  selector = selector || ''
+  selector = selector || '';
 
   while (index <= selector.length) {
     var ch = selector[index++];
@@ -41,7 +41,7 @@ function parse(selector) {
     }
   }
 
-  if (className.length) {
+  if (className.length) { // eslint-disable-line unicorn/explicit-length-check
     node.properties.className = className;
   }
 

--- a/index.js
+++ b/index.js
@@ -3,61 +3,45 @@
 /* Expose. */
 module.exports = parse;
 
-/* Characters */
-var dot = '.'.charCodeAt(0);
-var hash = '#'.charCodeAt(0);
-
 /* Parse a simple CSS selector into a HAST node. */
 function parse(selector) {
-  var id = null;
+  var index = 0;
   var className = [];
-  var value = selector || '';
-  var name = 'div';
-  var node;
-  var type = null;
-  var index = -1;
-  var code;
-  var length = value.length;
-  var subvalue;
+
+  var type;
   var lastIndex;
 
-  node = {
+  var node = {
     type: 'element',
-    tagName: null,
+    tagName: 'div',
     properties: {},
     children: []
   };
 
-  type = null;
+  selector = selector || ''
 
-  while (++index <= length) {
-    code = value.charCodeAt(index);
+  while (index <= selector.length) {
+    var ch = selector[index++];
 
-    if (!code || code === dot || code === hash) {
-      subvalue = value.slice(lastIndex, index);
+    if (!ch || ch === '.' || ch === '#') {
+      var subvalue = selector.slice(lastIndex, index - 1);
 
       if (subvalue) {
-        if (type === dot) {
+        if (type === '.') {
           className.push(subvalue);
-        } else if (type === hash) {
-          id = subvalue;
+        } else if (type === '#') {
+          node.properties.id = subvalue;
         } else {
-          name = subvalue;
+          node.tagName = subvalue;
         }
       }
 
-      lastIndex = index + 1;
-      type = code;
+      lastIndex = index;
+      type = ch;
     }
   }
 
-  node.tagName = name;
-
-  if (id) {
-    node.properties.id = id;
-  }
-
-  if (className.length !== 0) {
+  if (className.length) {
     node.properties.className = className;
   }
 


### PR DESCRIPTION
~~can't deal with the `unicorn/explicit-length-check` sorry... tried eslint disabling, seems to not work. I'm not `xo` user.~~

In reality with better tooling (rollup + uglify) you get 488 bytes minified and 316 bytes gzip with zopfli compression - and that is umd bundle which adds 30-50 bytes wrapper.

Browserify + ESMangle isn't good. Using them it seems 2x more minified size. And that's because browserify's wrapper is around 300-400 bytes minified.

As about the created bundles from the "build" script.. they even not included in the npm package? `files` field includes only index and there's no `main` field?